### PR TITLE
Add NEARBY_WIFI_DEVICES permission, required for Android 13+

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -21,6 +21,10 @@
         android:maxSdkVersion="32" />
     <uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />
     <uses-permission android:name="android.permission.CHANGE_NETWORK_STATE" />
+    <uses-permission
+        android:name="android.permission.NEARBY_WIFI_DEVICES"
+        android:usesPermissionFlags="neverForLocation"
+        tools:targetApi="tiramisu" />
 
     <application
         android:name=".TasksApplication"

--- a/app/src/main/java/live/ditto/compose/tasks/list/TasksListScreen.kt
+++ b/app/src/main/java/live/ditto/compose/tasks/list/TasksListScreen.kt
@@ -1,6 +1,5 @@
 package live.ditto.compose.tasks.list
 
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.ExtendedFloatingActionButton


### PR DESCRIPTION
This project was missing the `NEARBY_WIFI_DEVICES` permission in `AndroidManifest.xml`, which is required for Android 13 and newer.